### PR TITLE
Multi generator doesn't drop responses

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -658,6 +658,12 @@ class Foursquare(object):
                     _check_response(response)
                     yield response['response']
 
+        @property
+        def num_api_calls(self):
+          return len(self.requester.multi_requests) // MAX_MULTI_REQUESTS + (1 if len(self.requester.multi_requests) % MAX_MULTI_REQUESTS else 0)
+          ## OR ##
+          # import math
+          # math.ceil(len(self.requester.multi_requests) / MAX_MULTI_REQUESTS)
 
 """
 Network helper functions


### PR DESCRIPTION
Hi Mike

Nice work on the generator, although I've come up with an issue in my testing. I don't really like the way the generator throws an exception half way through processing a bunch of responses because it is possible that there is some remaining 200 responses which are valid, and that I'm interested in. So I've implemented a way to store the responses if an exception is thrown durning the yield section, and recover on a subsequent generator call. Although it's not ideal as you then need to iterate using an inner and outer loop: 

``` python
  while len(client.multi):
    try:
      for response in client.multi():
        print response
    except Exception, e:
      print e
```

Unless you have a better idea?

Benn
