### PR TITLE
Add 'suggestcompletion' to api endpoint

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -343,6 +343,10 @@ class Foursquare(object):
             """https://developer.foursquare.com/docs/venues/explore"""
             return self.GET('explore', params, multi=multi)
 
+        def suggestcompletion(self, params, multi=False):
+            """https://developer.foursquare.com/docs/venues/suggestcompletion"""
+            return self.GET('suggestcompletion', params, multi=multi)
+
         MAX_SEARCH_LIMIT = 50
         def search(self, params, multi=False):
             """https://developer.foursquare.com/docs/venues/search"""


### PR DESCRIPTION
Looking at the foursquare api documentation, there appears to be an api endpoint that isn't represented in the current foursquare api:

https://developer.foursquare.com/docs/venues/suggestcompletion

I've added this 'suggestcompletion' endpoint to the code.
