### PR TITLE
Adding HTTP_KWARGS as httplib2.Http(**HTTP_KWARGS)

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -42,6 +42,9 @@ NUM_REQUEST_RETRIES = 3
 # Max number of sub-requests per multi request
 MAX_MULTI_REQUESTS = 5
 
+# Keyworded Arguments passed to the httplib2.Http() request
+HTTP_KWARGS = {}
+
 
 # Generic foursquare exception
 class FoursquareException(Exception): pass
@@ -710,7 +713,7 @@ def _request_with_retry(url, data=None):
 
 def _process_request_with_httplib2(url, data=None):
     """Make the request and handle exception processing"""
-    h = httplib2.Http()
+    h = httplib2.Http(**HTTP_KWARGS)
     try:
         if data:
             datagen, headers = poster.encode.multipart_encode(data)


### PR DESCRIPTION
This way e.g. the timeout parameter can be used through HTTP_KWARGS = {'timeout': 5} (Closes #14). 

It also alows adding additional 'ca_certs' or 'disable_ssl_certificate_validation' arguments useful for bug #11.

See also: http://bitworking.org/projects/httplib2/doc/html/libhttplib2.html#httplib2.Http
