### PR TITLE
Changed 'response_type' to 'token'

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -107,7 +107,7 @@ class Foursquare(object):
             """Gets the url a user needs to access to give up a user token"""
             data = {
                 'client_id': self.client_id,
-                'response_type': u'code',
+                'response_type': u'token',
                 'redirect_uri': self.redirect_uri,
             }
             return '{AUTH_ENDPOINT}?{params}'.format(


### PR DESCRIPTION
'&response_type=code' no longer works for the auth_uri, foursquare's oauth docs state to use '&response_type=token' instead (https://developer.foursquare.com/overview/auth)
