### PR TITLE
Remove debug statement containing access_token

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -130,7 +130,6 @@ class Foursquare(object):
             url = u'{TOKEN_ENDPOINT}?{params}'.format(
                 TOKEN_ENDPOINT=TOKEN_ENDPOINT,
                 params=urllib.urlencode(data))
-            log.debug(u'GET: {0}'.format(url))
             # Get the response from the token uri and attempt to parse
             response = _request_with_retry(url)
             return response.get('access_token')


### PR DESCRIPTION
The removed statement was logging the following message:

```
GET url: https://api.foursquare.com/v2/users/self/checkins?oauth_token=XXXXXXXXXXXXXXXXXXXXXX&v=20130402 headers:{} data:
```

Logging sensitive user credentials (in this case OAuth v2 access token) is dangerous
