### PR TITLE
Fix double-encoding of url params from switch to requests library

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -164,7 +164,6 @@ class Foursquare(object):
             # Continue processing normal requests
             headers = self._get_headers()
             params = self._enrich_params(params)
-            params = self._urlencode_params(params)
             url = '{API_ENDPOINT}{path}'.format(
                 API_ENDPOINT=API_ENDPOINT,
                 path=path


### PR DESCRIPTION
Requests is already encoding the url parameters passed in as a dictionary
