### PR TITLE
[users] add in new endpoints

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -53,7 +53,7 @@ if NETWORK_DEBUG:
 # Default API version. Move this forward as the library is maintained and kept current
 API_VERSION_YEAR  = '2015'
 API_VERSION_MONTH = '02'
-API_VERSION_DAY   = '01'
+API_VERSION_DAY   = '02'
 API_VERSION = '{year}{month}{day}'.format(year=API_VERSION_YEAR, month=API_VERSION_MONTH, day=API_VERSION_DAY)
 
 # Library versioning matches supported foursquare API version
@@ -337,9 +337,21 @@ class Foursquare(object):
             """https://developer.foursquare.com/docs/users/photos"""
             return self.GET('{USER_ID}/photos'.format(USER_ID=USER_ID), params, multi=multi)
 
+        def tips(self, USER_ID=u'self', params={}, multi=False):
+            """https://developer.foursquare.com/docs/users/tips"""
+            return self.GET('{USER_ID}/tips'.format(USER_ID=USER_ID), params, multi=multi)
+
+        def todos(self, USER_ID=u'self', params={}, multi=False):
+            """https://developer.foursquare.com/docs/users/todos"""
+            return self.GET('{USER_ID}/todos'.format(USER_ID=USER_ID), params, multi=multi)
+
         def venuehistory(self, USER_ID=u'self', params={}, multi=False):
             """https://developer.foursquare.com/docs/users/venuehistory"""
             return self.GET('{USER_ID}/venuehistory'.format(USER_ID=USER_ID), params, multi=multi)
+
+        def venuelikes(self, USER_ID=u'self', params={}, multi=False):
+            """https://developer.foursquare.com/docs/users/venuelikes"""
+            return self.GET('{USER_ID}/venuelikes'.format(USER_ID=USER_ID), params, multi=multi)
 
         """
         Actions

--- a/foursquare/tests/test_users.py
+++ b/foursquare/tests/test_users.py
@@ -101,8 +101,20 @@ class UsersEndpointTestCase(BaseAuthenticatedEndpointTestCase):
         response = self.api.users.photos(params={'offset': 3})
         assert 'photos' in response
 
+    def test_tips(self):
+        response = self.api.users.tips()
+        assert 'tips' in response
+
+    def test_todos(self):
+        response = self.api.users.todos()
+        assert 'todos' in response
+
     def test_venuehistory(self):
         response = self.api.users.venuehistory()
+        assert 'venues' in response
+
+    def test_venuelikes(self):
+        response = self.api.users.venuelikes()
         assert 'venues' in response
 
     """


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/mLewisLogic/foursquare/issues/49), not all user aspect endpoints were supported. This brings them up to speed, minus `tastes`, which doesn't even work in the API Explorer (thanks Foursquare).