### PR TITLE
Deprecate Badges Endpoint

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ omit =
     */site-packages/nose/*
     */unittest2/*
 
+[report]
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 - '2.7'
 - '3.4'
 install:
-- pip install coverage six --use-mirrors
-- pip install . --use-mirrors
+- pip install coverage six
+- pip install .
 script:
 - nosetests --with-coverage --cover-package=foursquare
 env:

--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -301,10 +301,6 @@ class Foursquare(object):
         """
         Aspects
         """
-        def badges(self, USER_ID=u'self', multi=False):
-            """https://developer.foursquare.com/docs/users/badges"""
-            return self.GET('{USER_ID}/badges'.format(USER_ID=USER_ID), multi=multi)
-
         def checkins(self, USER_ID=u'self', params={}, multi=False):
             """https://developer.foursquare.com/docs/users/checkins"""
             return self.GET('{USER_ID}/checkins'.format(USER_ID=USER_ID), params, multi=multi)

--- a/foursquare/tests/test_multi.py
+++ b/foursquare/tests/test_multi.py
@@ -21,7 +21,6 @@ class MultiEndpointTestCase(BaseAuthenticatedEndpointTestCase):
         user_response = self.api.users()
         assert 'user' in user_response
         # Resume loading the multi sub-requests
-        self.api.users.badges(multi=True)
         # Throw a call with multiple params in the middle to make sure it gets encoded correctly
         # and won't affect the other api calls that share the same http request
         self.api.pages.venues('1070527', params={'limit': 10, 'offset': 10}, multi=True)
@@ -32,7 +31,7 @@ class MultiEndpointTestCase(BaseAuthenticatedEndpointTestCase):
         self.api.lists(self.default_listid, multi=True)
         self.api.photos(self.default_photoid, multi=True)
         # We are expecting certain responses...
-        expected_responses = ('user', 'leaderboard', 'badges', 'venues', 'lists', 'categories', 'recent', 'tip', 'list', 'photo',)
+        expected_responses = ('user', 'leaderboard', 'venues', 'lists', 'categories', 'recent', 'tip', 'list', 'photo',)
         # Make sure our utility functions are working
         assert len(self.api.multi) == len(expected_responses), u'{0} requests queued. Expecting {1}'.format(
             len(self.api.multi),

--- a/foursquare/tests/test_users.py
+++ b/foursquare/tests/test_users.py
@@ -40,11 +40,6 @@ class UsersEndpointTestCase(BaseAuthenticatedEndpointTestCase):
     """
     Aspects
     """
-    def test_badges(self):
-        response = self.api.users.badges()
-        assert 'sets' in response
-        assert 'badges' in response
-
     def test_checkins(self):
         response = self.api.users.checkins()
         assert 'checkins' in response


### PR DESCRIPTION
Per https://developer.foursquare.com/docs/users/badges, the badges endpoint has been deprecated via #75 

This PR is simply to remove the function badges calling the deprecated endpoint and additionally the test for the badges endpoint. 