### PR TITLE
Use two digits for the month

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -52,7 +52,7 @@ if NETWORK_DEBUG:
 
 # Default API version. Move this forward as the library is maintained and kept current
 API_VERSION_YEAR  = '2019'
-API_VERSION_MONTH = '2'
+API_VERSION_MONTH = '02'
 API_VERSION_DAY   = '12'
 API_VERSION = '{year}{month}{day}'.format(year=API_VERSION_YEAR, month=API_VERSION_MONTH, day=API_VERSION_DAY)
 


### PR DESCRIPTION
The current implementation raises a `ParamError`:

> The Foursquare API no longer supports requests that pass in a version v <= 20120609. For more details see https://developer.foursquare.com/overview/versioning

Foursquare is expecting `v=YYYYMMDD`. 