### PR TITLE
docs: fix simple typo, paramater -> parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Dependencies:
     # Build the authorization url for your app
     auth_uri = client.oauth.auth_url()
 
-Redirect your user to the address *auth_uri* and let them authorize your app. They will then be redirected to your *redirect_uri*, with a query paramater of code=XX_CODE_RETURNED_IN_REDIRECT_XX. In your webserver, parse out the *code* value, and use it to call client.oauth.get_token()
+Redirect your user to the address *auth_uri* and let them authorize your app. They will then be redirected to your *redirect_uri*, with a query parameter of code=XX_CODE_RETURNED_IN_REDIRECT_XX. In your webserver, parse out the *code* value, and use it to call client.oauth.get_token()
 
     # Interrogate foursquare's servers to get the user's access_token
     access_token = client.oauth.get_token('XX_CODE_RETURNED_IN_REDIRECT_XX')


### PR DESCRIPTION
There is a small typo in README.md.

Closes #98